### PR TITLE
Fix tab colour mismatch on Settings | Packages page

### DIFF
--- a/plugin/controllers/views/responsive/ajax/settings.tmpl
+++ b/plugin/controllers/views/responsive/ajax/settings.tmpl
@@ -121,11 +121,11 @@
 						<div id="content_main2">
 							<div class="row clearfix">
 								<div class="col-xs-12">
-									<ul class="nav nav-tabs" >
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn1' >$tstrings['update']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn2' >$tstrings['installed']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn3' >$tstrings['all']</a></li>
-										<li><a data-toggle="tab" href='#tab' class="pkgbtn" id='pkgbtn4' >$tstrings['more']</a></li>
+									<ul class="nav nav-tabs tab--skinned">
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn1">$tstrings['update']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn2">$tstrings['installed']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn3">$tstrings['all']</a></li>
+										<li><a data-toggle="tab" href="#tab" class="pkgbtn" id="pkgbtn4">$tstrings['more']</a></li>
 									</ul>
 								</div>
 							</div>


### PR DESCRIPTION
Fix selected tab colour mismatch on `Settings` | `Packages` page

<img width="398" alt="" src="https://user-images.githubusercontent.com/9741693/161312153-5327fc3b-de01-4fc3-8d55-0e566eb81fee.png">
