### PR TITLE
Fix blank entry when no AutoTimers exist

### DIFF
--- a/sourcefiles/modern/js/autotimers.mjs
+++ b/sourcefiles/modern/js/autotimers.mjs
@@ -41,7 +41,13 @@
   }
 
   function forceToArray(value) {
-    return Array.isArray(value) ? value : [value];
+    let arr = [];
+    if (Array.isArray(value)) {
+        arr = value;
+    } else if (typeof value !== 'undefined') {
+        arr = [value];
+    }
+    return arr;
   }
 
   function keyValueSortWeight(key, order = 'asc') {


### PR DESCRIPTION
Fix blank entry when no AutoTimers exist

Bug:
<img width="1360" alt="" src="https://user-images.githubusercontent.com/9741693/161623667-529fa1fc-4430-4e24-9d35-9f827fc4266b.png">
